### PR TITLE
Scala logging wrapper updated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,14 +73,15 @@
       <version>13.0.1</version>
     </dependency>
     <dependency>
-      <groupId>com.weiglewilczek.slf4s</groupId>
-      <artifactId>slf4s_2.9.1</artifactId>
-      <version>1.0.7</version>
+      <groupId>com.typesafe</groupId>
+      <artifactId>scalalogging-slf4j_2.10</artifactId>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.6.6</version>
+      <version>1.7.2</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/main/scala/sorm/Instance.scala
+++ b/src/main/scala/sorm/Instance.scala
@@ -9,7 +9,7 @@ import jdbc._
 
 import sext._, embrace._
 import reflect.runtime.universe._
-import com.weiglewilczek.slf4s.Logging
+import com.typesafe.scalalogging.slf4j.Logging
 
 /**
  * The instance of SORM

--- a/src/main/scala/sorm/core/Initialization.scala
+++ b/src/main/scala/sorm/core/Initialization.scala
@@ -7,7 +7,7 @@ import jdbc._
 import tableSorters._
 
 import sext._, embrace._
-import com.weiglewilczek.slf4s.Logging
+import com.typesafe.scalalogging.slf4j.Logging
 
 object Initialization extends Logging {
 

--- a/src/main/scala/sorm/jdbc/Transactions.scala
+++ b/src/main/scala/sorm/jdbc/Transactions.scala
@@ -2,7 +2,6 @@ package sorm.jdbc
 
 import sext._, embrace._
 import java.sql.{Statement => JdbcStatement, SQLTransactionRollbackException, Connection, ResultSet}
-import com.weiglewilczek.slf4s.Logging
 import reflect.ClassTag
 
 trait Transactions {

--- a/src/main/scala/sorm/persisted/PersistedClass.scala
+++ b/src/main/scala/sorm/persisted/PersistedClass.scala
@@ -4,7 +4,7 @@ import sorm._
 import reflection._
 
 import sext._, embrace._
-import com.weiglewilczek.slf4s.Logging
+import com.typesafe.scalalogging.slf4j.Logging
 
 object PersistedClass extends Logging {
 

--- a/src/main/scala/sorm/pooling/ConnectionPool.scala
+++ b/src/main/scala/sorm/pooling/ConnectionPool.scala
@@ -1,7 +1,7 @@
 package sorm.pooling
 
 import sorm.jdbc.JdbcConnection
-import com.weiglewilczek.slf4s.Logging
+import com.typesafe.scalalogging.slf4j.Logging
 
 trait ConnectionPool extends Logging {
   protected def fetchConnection () : JdbcConnection

--- a/src/main/scala/sorm/query/AbstractSqlComposition.scala
+++ b/src/main/scala/sorm/query/AbstractSqlComposition.scala
@@ -8,7 +8,7 @@ import sorm.persisted._
 import sorm.abstractSql.{AbstractSql => AS}
 import sorm.abstractSql.Combinators._
 import Query._
-import com.weiglewilczek.slf4s.Logging
+import com.typesafe.scalalogging.slf4j.Logging
 
 object AbstractSqlComposition extends Logging {
 

--- a/src/test/scala/sorm/jdbc/JdbcConnectionSimulator.scala
+++ b/src/test/scala/sorm/jdbc/JdbcConnectionSimulator.scala
@@ -1,6 +1,6 @@
 package sorm.jdbc
 
-import com.weiglewilczek.slf4s.Logging
+import com.typesafe.scalalogging.slf4j.Logging
 import java.sql.ResultSet
 
 class JdbcConnectionSimulator


### PR DESCRIPTION
Changed the Scala logging wrapper (for slf4j) from slf4s to ScalaLogging
since the former is no longer maintained
Changed the scope of slf4j-simple (slf4j binding) to "test" in order to
remove it as a transitive dependency for consumers of this library
