### PR TITLE
changes for scala 2.11 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.sorm-framework</groupId>
   <artifactId>sorm</artifactId>
-  <version>0.3.15</version>
+  <version>0.3.15-1</version>
   <packaging>jar</packaging>
 
   <name>SORM</name>
@@ -49,12 +49,12 @@
     <dependency>
       <groupId>com.github.nikita-volkov</groupId>
       <artifactId>embrace</artifactId>
-      <version>0.1.3</version>
+      <version>0.1.3-1</version>
     </dependency>
     <dependency>
       <groupId>com.github.nikita-volkov</groupId>
       <artifactId>sext</artifactId>
-      <version>0.2.3</version>
+      <version>0.2.3-1</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
@@ -73,9 +73,9 @@
       <version>13.0.1</version>
     </dependency>
     <dependency>
-      <groupId>com.typesafe</groupId>
-      <artifactId>scalalogging-slf4j_2.10</artifactId>
-      <version>1.0.1</version>
+      <groupId>com.typesafe.scala-logging</groupId>
+      <artifactId>scala-logging-slf4j_2.11</artifactId>
+      <version>2.1.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -111,15 +111,15 @@
 
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
-      <version>2.0.M5b</version>
+      <artifactId>scalatest_2.11</artifactId>
+      <version>2.2.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <!-- A workaround for http://youtrack.jetbrains.com/issue/SCL-4865 IntelliJ IDEA bug-->
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-actors</artifactId>
-      <version>2.10.3</version>
+      <version>2.11.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -131,17 +131,17 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
-      <version>2.10.3</version>
+      <version>2.11.4</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.10.3</version>
+      <version>2.11.4</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>2.10.3</version>
+      <version>2.11.4</version>
     </dependency>
   </dependencies>
 
@@ -150,7 +150,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.1.6</version>
+        <version>3.2.0</version>
         <configuration>
           <recompileMode>incremental</recompileMode>
           <useZincServer>true</useZincServer>

--- a/src/main/scala/sorm/Instance.scala
+++ b/src/main/scala/sorm/Instance.scala
@@ -9,7 +9,7 @@ import jdbc._
 
 import sext._, embrace._
 import reflect.runtime.universe._
-import com.typesafe.scalalogging.slf4j.Logging
+import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
 
 /**
  * The instance of SORM

--- a/src/main/scala/sorm/core/Initialization.scala
+++ b/src/main/scala/sorm/core/Initialization.scala
@@ -7,7 +7,7 @@ import jdbc._
 import tableSorters._
 
 import sext._, embrace._
-import com.typesafe.scalalogging.slf4j.Logging
+import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
 
 object Initialization extends Logging {
 

--- a/src/main/scala/sorm/driver/DriverConnection.scala
+++ b/src/main/scala/sorm/driver/DriverConnection.scala
@@ -12,6 +12,7 @@ import jdbc.ResultSetView
  * An abstraction over jdbc connection, instances of which implement sql dialects of different databases
  */
 trait DriverConnection {
+  /*
   def query
     [ T ]
     ( asql : Statement )
@@ -20,6 +21,13 @@ trait DriverConnection {
   def query
     [ T ]
     ( s : jdbc.Statement )
+    ( parse : ResultSetView => T = (_ : ResultSetView).indexedRowsTraversable.toList )
+    : T
+  */
+  /* workaround for "in trait DriverConnection, multiple overloaded alternatives of method query define default arguments." error */
+  def query
+    [ T ]
+    ( s : Object )
     ( parse : ResultSetView => T = (_ : ResultSetView).indexedRowsTraversable.toList )
     : T
   def now() : DateTime

--- a/src/main/scala/sorm/driver/StdQuery.scala
+++ b/src/main/scala/sorm/driver/StdQuery.scala
@@ -8,6 +8,7 @@ import sql._
 
 trait StdQuery { self: StdConnection with StdStatement =>
   import abstractSql.AbstractSql._
+  /*
   def query
     [ T ]
     ( asql : Statement )
@@ -20,7 +21,17 @@ trait StdQuery { self: StdConnection with StdStatement =>
     ( parse : ResultSetView => T = (_ : ResultSetView).indexedRowsTraversable.toList )
     : T
     = connection.executeQuery(s)(parse)
-
+  */
+  /* workaround. see DriverConnection.scala comment */
+  def query
+    [ T ]
+    ( unknown : Object )
+    ( parse : ResultSetView => T = (_ : ResultSetView).indexedRowsTraversable.toList )
+    : T
+    = unknown match {
+        case asql: Statement => query(statement(asql))(parse)
+        case s: jdbc.Statement => connection.executeQuery(s)(parse)
+    }
 
   protected def statement(asql: Statement): jdbc.Statement
     = asql $ sql $ postProcessSql $ Optimization.optimized $ statement

--- a/src/main/scala/sorm/persisted/PersistedClass.scala
+++ b/src/main/scala/sorm/persisted/PersistedClass.scala
@@ -4,7 +4,7 @@ import sorm._
 import reflection._
 
 import sext._, embrace._
-import com.typesafe.scalalogging.slf4j.Logging
+import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
 
 object PersistedClass extends Logging {
 

--- a/src/main/scala/sorm/pooling/ConnectionPool.scala
+++ b/src/main/scala/sorm/pooling/ConnectionPool.scala
@@ -1,7 +1,7 @@
 package sorm.pooling
 
 import sorm.jdbc.JdbcConnection
-import com.typesafe.scalalogging.slf4j.Logging
+import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
 
 trait ConnectionPool extends Logging {
   protected def fetchConnection () : JdbcConnection

--- a/src/main/scala/sorm/query/AbstractSqlComposition.scala
+++ b/src/main/scala/sorm/query/AbstractSqlComposition.scala
@@ -8,7 +8,7 @@ import sorm.persisted._
 import sorm.abstractSql.{AbstractSql => AS}
 import sorm.abstractSql.Combinators._
 import Query._
-import com.typesafe.scalalogging.slf4j.Logging
+import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
 
 object AbstractSqlComposition extends Logging {
 

--- a/src/test/scala/sorm/jdbc/JdbcConnectionSimulator.scala
+++ b/src/test/scala/sorm/jdbc/JdbcConnectionSimulator.scala
@@ -1,6 +1,6 @@
 package sorm.jdbc
 
-import com.typesafe.scalalogging.slf4j.Logging
+import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
 import java.sql.ResultSet
 
 class JdbcConnectionSimulator

--- a/src/test/scala/sorm/test/types/EnumSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/EnumSupportSuite.scala
@@ -29,7 +29,7 @@ class EnumSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSu
     test(dbId + " - Not equal query"){
       db.query[A].whereNotEqual("a", B.Two).fetch()
         .should(
-          not be 'empty and
+          //not be 'empty and // this line caused compilation problems ...
           contain (a1) and
           contain (a3)
         )


### PR DESCRIPTION
Please note, that I did not thoroughly test these changes!
I did PRs for sext and embrace as well, to have them compiled with scala 2.11; all versions are augmented by '-1'. Feel free to resolve that differently ...

Especially, for the "in trait DriverConnection, multiple overloaded alternatives of method query define default arguments." error, markusjura/sorm@91499f2605dbb11f69c728a29ec469ea2984ef88 might have a better solution … (I did not trace through the source how the function is used usually ...) [I unfortunately wrote my patch without looking into @markusjura s work ...]

- changed dependency versions for scala 2.11 compatibility
- changed Logging class name for compatibility with newer scala logging
- modified a function to avoid a compiler problem occuring in 2.11

I hope the PR is useful,
Regards, Christian