### PR TITLE
Added IgnoreCaseLike operator

### DIFF
--- a/src/main/scala/sorm/Dsl.scala
+++ b/src/main/scala/sorm/Dsl.scala
@@ -17,6 +17,7 @@ object Dsl {
     def larger(v: Any)         = Larger(p, v)
     def largerOrEqual(v: Any)  = LargerOrEqual(p, v)
     def like(v: Any)           = Like(p, v)           
+    def ignoreCaseLike(v: Any) = IgnoreCaseLike(p, v)
     def notLike(v: Any)        = NotLike(p, v)        
     def regex(v: Any)          = Regex(p, v)          
     def notRegex(v: Any)       = NotRegex(p, v)       

--- a/src/main/scala/sorm/Querier.scala
+++ b/src/main/scala/sorm/Querier.scala
@@ -117,6 +117,7 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
                 case Querier.Smaller(p, v)        => (p, v, Smaller)
                 case Querier.SmallerOrEqual(p, v) => (p, v, SmallerOrEqual)
                 case Querier.Like(p, v)           => (p, v, Like) 
+                case Querier.IgnoreCaseLike(p, v) => (p, v, IgnoreCaseLike) 
                 case Querier.NotLike(p, v)        => (p, v, NotLike) 
                 case Querier.Regex(p, v)          => (p, v, Regex) 
                 case Querier.NotRegex(p, v)       => (p, v, NotRegex) 
@@ -178,6 +179,9 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
   def whereLike( p : String, v : Any ) 
     = where( p, v, Like )
 
+  def whereIgnoreCaseLike( p : String, v : Any ) 
+    = where( p, v, IgnoreCaseLike )    
+
   def whereNotLike( p : String, v : Any ) 
     = where( p, v, NotLike )
 
@@ -227,6 +231,7 @@ object Querier {
   case class Smaller ( p : String, v : Any ) extends Filter
   case class SmallerOrEqual ( p : String, v : Any ) extends Filter
   case class Like ( p : String, v : Any ) extends Filter
+  case class IgnoreCaseLike ( p : String, v : Any ) extends Filter
   case class NotLike ( p : String, v : Any ) extends Filter
   case class Regex ( p : String, v : Any ) extends Filter
   case class NotRegex ( p : String, v : Any ) extends Filter

--- a/src/main/scala/sorm/abstractSql/AbstractSql.scala
+++ b/src/main/scala/sorm/abstractSql/AbstractSql.scala
@@ -93,6 +93,7 @@ object AbstractSql {
   case object Smaller extends Operator
   case object SmallerOrEqual extends Operator
   case object Like extends Operator
+  case object IgnoreCaseLike extends Operator
   case object NotLike extends Operator
   case object Regexp extends Operator
   case object NotRegexp extends Operator

--- a/src/main/scala/sorm/abstractSql/SqlComposition.scala
+++ b/src/main/scala/sorm/abstractSql/SqlComposition.scala
@@ -20,6 +20,7 @@ object SqlComposition {
         case Smaller        => Sql.Smaller
         case SmallerOrEqual => Sql.SmallerOrEqual
         case Like           => Sql.Like
+        case IgnoreCaseLike => Sql.IgnoreCaseLike
         case NotLike        => Sql.NotLike
         case Regexp         => Sql.Regexp
         case NotRegexp      => Sql.NotRegexp

--- a/src/main/scala/sorm/driver/Postgres.scala
+++ b/src/main/scala/sorm/driver/Postgres.scala
@@ -2,6 +2,7 @@ package sorm.driver
 
 import sorm._, ddl._, jdbc._
 import sext._, embrace._
+import sql.Sql
 
 class Postgres (protected val connection : JdbcConnection)
   extends DriverConnection
@@ -47,8 +48,10 @@ class Postgres (protected val connection : JdbcConnection)
   //  dirty: implies that the only thing returned is an id column
   override def insertAndGetGeneratedKeys(table: String, values: Iterable[(String, Any)])
     = super.insertAndGetGeneratedKeys(table, values).take(1)
-  protected def template ( sql : Sql ) : String
-    = sql match {
+  override protected def template ( sql : Sql ) : String
+    = {
+      import sorm.sql.Sql._
+      sql match {
         case IgnoreCaseLike => "ILIKE"
         case _ => super.template(sql)
       }

--- a/src/main/scala/sorm/driver/Postgres.scala
+++ b/src/main/scala/sorm/driver/Postgres.scala
@@ -47,4 +47,11 @@ class Postgres (protected val connection : JdbcConnection)
   //  dirty: implies that the only thing returned is an id column
   override def insertAndGetGeneratedKeys(table: String, values: Iterable[(String, Any)])
     = super.insertAndGetGeneratedKeys(table, values).take(1)
+  protected def template ( sql : Sql ) : String
+    = sql match {
+        case IgnoreCaseLike => "ILIKE"
+        case _ => super.template(sql)
+      }
+    }
+
 }

--- a/src/main/scala/sorm/driver/StdSqlRendering.scala
+++ b/src/main/scala/sorm/driver/StdSqlRendering.scala
@@ -155,6 +155,8 @@ trait StdSqlRendering {
           "<="
         case Like =>
           "LIKE"
+        case IgnoreCaseLike =>
+          "LIKE"
         case NotLike =>
           "NOT LIKE"
         case Regexp =>

--- a/src/main/scala/sorm/query/AbstractSqlComposition.scala
+++ b/src/main/scala/sorm/query/AbstractSqlComposition.scala
@@ -77,6 +77,9 @@ object AbstractSqlComposition extends Logging {
         case Filter(Like, m: ValueMapping, v) => 
           comparing( m, AS.Like, v )
 
+        case Filter(IgnoreCaseLike, m: ValueMapping, v) => 
+          comparing( m, AS.IgnoreCaseLike, v )          
+
         case Filter(NotLike, m: ValueMapping, v) => 
           comparing( m, AS.NotLike, v )
 

--- a/src/main/scala/sorm/query/Query.scala
+++ b/src/main/scala/sorm/query/Query.scala
@@ -54,6 +54,7 @@ object Query {
   case object Smaller extends Operator
   case object SmallerOrEqual extends Operator
   case object Like extends Operator
+  case object IgnoreCaseLike extends Operator
   case object NotLike extends Operator
   case object Regex extends Operator
   case object NotRegex extends Operator

--- a/src/main/scala/sorm/sql/Sql.scala
+++ b/src/main/scala/sorm/sql/Sql.scala
@@ -153,6 +153,7 @@ object Sql {
   case object Smaller extends ComparisonOperator
   case object SmallerOrEqual extends ComparisonOperator
   case object Like extends ComparisonOperator
+  case object IgnoreCaseLike extends ComparisonOperator
   case object NotLike extends ComparisonOperator
   case object Regexp extends ComparisonOperator
   case object NotRegexp extends ComparisonOperator


### PR DESCRIPTION
Hi

Added IgnoreCaseLike operator to perform a non sensitive ILIKE in PostgreSQL. ILIKE is operator supported  by PostgreSQL only, therefore default implementation of IgnoreCaseLike defined in StdSqlRendering uses LIKE. In Postgres driver IgnoreCaseLike is override to use ILIKE.