### PR TITLE
Update to scala-logging 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
     </dependency>
     <dependency>
       <groupId>com.typesafe.scala-logging</groupId>
-      <artifactId>scala-logging-slf4j_2.11</artifactId>
-      <version>2.1.2</version>
+      <artifactId>scala-logging_2.11</artifactId>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/scala/sorm/Instance.scala
+++ b/src/main/scala/sorm/Instance.scala
@@ -9,7 +9,7 @@ import jdbc._
 
 import sext._, embrace._
 import reflect.runtime.universe._
-import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
+import com.typesafe.scalalogging.{StrictLogging => Logging}
 
 /**
  * The instance of SORM

--- a/src/main/scala/sorm/core/Initialization.scala
+++ b/src/main/scala/sorm/core/Initialization.scala
@@ -7,7 +7,7 @@ import jdbc._
 import tableSorters._
 
 import sext._, embrace._
-import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
+import com.typesafe.scalalogging.{StrictLogging => Logging}
 
 object Initialization extends Logging {
 

--- a/src/main/scala/sorm/persisted/PersistedClass.scala
+++ b/src/main/scala/sorm/persisted/PersistedClass.scala
@@ -4,7 +4,7 @@ import sorm._
 import reflection._
 
 import sext._, embrace._
-import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
+import com.typesafe.scalalogging.{StrictLogging => Logging}
 
 object PersistedClass extends Logging {
 

--- a/src/main/scala/sorm/pooling/ConnectionPool.scala
+++ b/src/main/scala/sorm/pooling/ConnectionPool.scala
@@ -1,7 +1,7 @@
 package sorm.pooling
 
 import sorm.jdbc.JdbcConnection
-import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
+import com.typesafe.scalalogging.{StrictLogging => Logging}
 
 trait ConnectionPool extends Logging {
   protected def fetchConnection () : JdbcConnection

--- a/src/main/scala/sorm/query/AbstractSqlComposition.scala
+++ b/src/main/scala/sorm/query/AbstractSqlComposition.scala
@@ -8,7 +8,7 @@ import sorm.persisted._
 import sorm.abstractSql.{AbstractSql => AS}
 import sorm.abstractSql.Combinators._
 import Query._
-import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
+import com.typesafe.scalalogging.{StrictLogging => Logging}
 
 object AbstractSqlComposition extends Logging {
 

--- a/src/test/scala/sorm/jdbc/JdbcConnectionSimulator.scala
+++ b/src/test/scala/sorm/jdbc/JdbcConnectionSimulator.scala
@@ -1,6 +1,6 @@
 package sorm.jdbc
 
-import com.typesafe.scalalogging.slf4j.{StrictLogging => Logging}
+import com.typesafe.scalalogging.{StrictLogging => Logging}
 import java.sql.ResultSet
 
 class JdbcConnectionSimulator


### PR DESCRIPTION
https://github.com/typesafehub/scalalogging has been refactored a little and an open source lib that I am using requires the new version. Would it be possible to upgrade this dependency?