### PR TITLE
Fix pb with time zones

### DIFF
--- a/src/main/scala/sorm/joda/Extensions.scala
+++ b/src/main/scala/sorm/joda/Extensions.scala
@@ -20,7 +20,7 @@ object Extensions {
 
 
   implicit class DateToJoda ( val self : java.sql.Date ) extends AnyVal {
-    def toJoda = LocalDate.fromDateFields(self)
+    def toJoda = LocalTime.fromMillisOfDay(sqlTime.getTime)
   }
 
   implicit class TimeToJoda ( val self : java.sql.Time ) extends AnyVal {

--- a/src/main/scala/sorm/joda/Extensions.scala
+++ b/src/main/scala/sorm/joda/Extensions.scala
@@ -20,7 +20,7 @@ object Extensions {
 
 
   implicit class DateToJoda ( val self : java.sql.Date ) extends AnyVal {
-    def toJoda = LocalTime.fromDateFields(self)
+    def toJoda = LocalDate.fromDateFields(self)
   }
 
   implicit class TimeToJoda ( val self : java.sql.Time ) extends AnyVal {

--- a/src/main/scala/sorm/joda/Extensions.scala
+++ b/src/main/scala/sorm/joda/Extensions.scala
@@ -20,11 +20,11 @@ object Extensions {
 
 
   implicit class DateToJoda ( val self : java.sql.Date ) extends AnyVal {
-    def toJoda = LocalTime.fromMillisOfDay(sqlTime.getTime)
+    def toJoda = LocalTime.fromDateFields(self)
   }
 
   implicit class TimeToJoda ( val self : java.sql.Time ) extends AnyVal {
-    def toJoda = LocalTime.fromDateFields(self)
+    def toJoda = LocalTime.fromMillisOfDay(self.getTime)
   }
 
   implicit class TimestampToJoda ( val self : java.sql.Timestamp ) extends AnyVal {


### PR DESCRIPTION
First of all, this is my first pull request and I'm not very familiar with git all in all, please forgive me if I made something wrong.

I've just started using sorm and am happy with it but I must say I already had two dissapointments:
1) I had to change all my java8 dates into joda versions... since apparently joda classes have been somehow integrated as standard java8 classes I was happy to use the later.
2) a very simple "create / save / query" scenario led me to surprisign results: dates all were 1hour ahead! After some investigation I understood that it was the java.sql.Date intermediate that made some trouble.

LocalTime.fromDateFields(sqlTime) was not taking care of zones, thus potentially adding offset to the SQL date (write / read same joda date would be differents!)

I ran the small following test on my computer that is GMT+1 I believe:

val lt = new LocalTime(6,0) // 06:00:00.000
val sqlTime = new java.sql.Time(lt.getMillisOfDay) // 07:00:00
sqlTime.getTimezoneOffset // -60
LocalTime.fromDateFields(sqlTime) // 07:00:00.000
LocalTime.fromMillisOfDay(sqlTime.getTime) // 06:00:00.000
new LocalTime(sqlTime.getTime, DateTimeZone.forID("UTC")) // 06:00:00.000

Thanks!