### PR TITLE
Add type safe query by macro.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Java
+*.class
+*.jar
+*.war
+*.ear
+
+# Eclipse
+.project
+.classpath
+.settings
+
+# Idea
+.idea
+*.iml
+*.iws
+*.ipr
+
+# OS
+Thumbs.db
+.DS_Store
+
+# Gradle
+.gradle
+!gradle-wrapper.jar
+
+# Maven
+target/
+
+# Build
+out/
+build/
+bin/
+
+# Other
+*.log
+*.swp
+*.bak

--- a/src/main/scala/sorm/Querier.scala
+++ b/src/main/scala/sorm/Querier.scala
@@ -1,7 +1,9 @@
 package sorm
 
 import sext._, embrace._
+import sorm.macroimpl.QuerierMacro
 import reflect.runtime.universe._
+import scala.language.experimental.macros
 
 import sorm._
 import mappings._
@@ -15,7 +17,8 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
 
   /**
    * Fetch matching entities from db.
-   * @return A stream of entity instances with [[sorm.Persisted]] mixed in
+    *
+    * @return A stream of entity instances with [[sorm.Persisted]] mixed in
    */
   def fetch () : Stream[T with Persisted]
     = fetchIds()
@@ -28,7 +31,8 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
 
   /**
    * Fetch ids of matching entities stored in db.
-   * @return A stream of ids
+    *
+    * @return A stream of ids
    */
   def fetchIds () : Stream[Long]
     = connector.withConnection { cx =>
@@ -37,7 +41,8 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
 
   /**
    * Fetch only one entity ensuring that `limit(1)` is applied to the query.
-   * @return An option of entity instance with [[sorm.Persisted]] mixed in
+    *
+    * @return An option of entity instance with [[sorm.Persisted]] mixed in
    */
   def fetchOne () : Option[T with Persisted]
     = limit(1).fetch().headOption
@@ -64,7 +69,8 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
 
   /**
    * Replace all matching entities stored in db with the value provided
-   * @param value A value to replace the existing entities with
+    *
+    * @param value A value to replace the existing entities with
    * @return A list of saved entities with [[sorm.Persisted]] mixed in
    */
   def replace ( value : T ) : List[T with Persisted]
@@ -86,6 +92,9 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
    */
   def order ( p : String, reverse : Boolean = false ) : Querier[T]
     = query.order.toVector :+ Order(Path.mapping(query.mapping, p), reverse) $ (x => copy(order = x))
+
+  def orderBy(p : T => Any, reverse : Boolean = false) =
+    macro QuerierMacro.orderByImpl[T]
 
   /**
    * Limit the amount of entities to be fetched
@@ -157,58 +166,94 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
    * @param v A value to compare with
    * @return A new instance of `Querier` with this filter applied
    */
-  def whereEqual ( p : String, v : Any )
+  def whereEqual ( p : String, v : Any ) : Querier[T]
     = where( p, v, Equal )
 
-  def whereNotEqual ( p : String, v : Any )
-    = where( p, v, NotEqual )
+  def whereEqual[A] ( p : T with Persisted => A, v : A ) : Querier[T]
+    = macro QuerierMacro.whereEqualImpl[T,A]
 
-  def whereLarger ( p : String, v : Any )
-    = where( p, v, Larger )
+  def whereNotEqual ( p : String, v : Any ) : Querier[T]
+    = where( p, v, Equal )
 
-  def whereLargerOrEqual ( p : String, v : Any )
-    = where( p, v, LargerOrEqual )
+  def whereNotEqual[A] ( p : T with Persisted => A, v : A ) : Querier[T]
+    = macro QuerierMacro.whereNotEqualImpl[T,A]
 
-  def whereSmaller ( p : String, v : Any ) 
-    = where( p, v, Smaller )
+  def whereLarger ( p : String, v : Any ) : Querier[T]
+    = where( p, v, Equal )
 
-  def whereSmallerOrEqual ( p : String, v : Any )
-    = where( p, v, SmallerOrEqual )
+  def whereLarger[A] ( p : T with Persisted => A, v : A ) : Querier[T]
+    = macro QuerierMacro.whereLargerImpl[T,A]
 
-  def whereLike( p : String, v : Any ) 
-    = where( p, v, Like )
+  def whereLargerOrEqual ( p : String, v : Any ) : Querier[T]
+    = where( p, v, Equal )
 
-  def whereNotLike( p : String, v : Any ) 
-    = where( p, v, NotLike )
+  def whereLargerOrEqual[A] ( p : T with Persisted => A, v : A ) : Querier[T]
+    = macro QuerierMacro.whereLargerOrEqualImpl[T,A]
 
-  def whereRegex( p : String, v : Any ) 
+  def whereSmaller ( p : String, v : Any ) : Querier[T]
+    = where( p, v, Equal )
+
+  def whereSmaller[A] ( p : T with Persisted => A, v : A ) : Querier[T]
+    = macro QuerierMacro.whereSmallerImpl[T,A]
+
+  def whereSmallerOrEqual ( p : String, v : Any ) : Querier[T]
+    = where( p, v, Equal )
+
+  def whereSmallerOrEqual[A] ( p : T with Persisted => A, v : A ) : Querier[T]
+    = macro QuerierMacro.whereSmallerOrEqualImpl[T,A]
+
+  def whereLike ( p : String, v : Any ) : Querier[T]
+    = where( p, v, Equal )
+
+  def whereLike ( p : T with Persisted => String, v : String ) : Querier[T]
+    = macro QuerierMacro.whereLikeImpl[T]
+
+  def whereNotLike ( p : String, v : Any ) : Querier[T]
+    = where( p, v, Equal )
+
+  def whereNotLike ( p : T with Persisted => String, v : String ) : Querier[T]
+    = macro QuerierMacro.whereNotLikeImpl[T]
+
+  def whereIn ( p : String, v : Any ) : Querier[T]
+    = where( p, v, Equal )
+
+  def whereIn[A] ( p : T with Persisted => A, v : Seq[A] ) : Querier[T]
+    = macro QuerierMacro.whereInImpl[T,A]
+
+  def whereNotIn ( p : String, v : Any ) : Querier[T]
+    = where( p, v, Equal )
+
+  def whereNotIn[A] ( p : T with Persisted => A, v : Seq[A] ) : Querier[T]
+    = macro QuerierMacro.whereNotInImpl[T,A]
+
+  def whereRegex( p : String, v : Any ) : Querier[T]
     = where( p, v, Regex )
 
-  def whereNotRegex( p : String, v : Any ) 
+  def whereRegex ( p : T with Persisted => String, v : String ) : Querier[T]
+    = macro QuerierMacro.whereRegexImpl[T]
+
+  def whereNotRegex( p : String, v : Any ) : Querier[T]
     = where( p, v, NotRegex )
 
-  def whereIn ( p : String, v : Any ) 
-    = where( p, v, In )
+  def whereNotRegex ( p : T with Persisted => String, v : String ) : Querier[T]
+    = macro QuerierMacro.whereNotRegexImpl[T]
 
-  def whereNotIn ( p : String, v : Any ) 
-    = where( p, v, NotIn )
-
-  def whereContains ( p : String, v : Any ) 
+  def whereContains ( p : String, v : Any ) : Querier[T]
     = where( p, v, Contains )
 
-  def whereNotContains ( p : String, v : Any ) 
+  def whereNotContains ( p : String, v : Any ) : Querier[T]
     = where( p, v, NotContains )
 
-  def whereConstitutes ( p : String, v : Any ) 
+  def whereConstitutes ( p : String, v : Any ) : Querier[T]
     = where( p, v, Constitutes )
 
-  def whereNotConstitutes ( p : String, v : Any ) 
+  def whereNotConstitutes ( p : String, v : Any ) : Querier[T]
     = where( p, v, NotConstitutes )
 
-  def whereIncludes ( p : String, v : Any ) 
+  def whereIncludes ( p : String, v : Any )  : Querier[T]
     = where( p, v, Includes )
 
-  def whereNotIncludes ( p : String, v : Any ) 
+  def whereNotIncludes ( p : String, v : Any ) : Querier[T]
     = where( p, v, NotIncludes )
 
 }

--- a/src/main/scala/sorm/Querier.scala
+++ b/src/main/scala/sorm/Querier.scala
@@ -173,55 +173,55 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
     = macro QuerierMacro.whereEqualImpl[T,A]
 
   def whereNotEqual ( p : String, v : Any ) : Querier[T]
-    = where( p, v, Equal )
+    = where( p, v, NotEqual )
 
   def whereNotEqual[A] ( p : T with Persisted => A, v : A ) : Querier[T]
     = macro QuerierMacro.whereNotEqualImpl[T,A]
 
   def whereLarger ( p : String, v : Any ) : Querier[T]
-    = where( p, v, Equal )
+    = where( p, v, Larger )
 
   def whereLarger[A] ( p : T with Persisted => A, v : A ) : Querier[T]
     = macro QuerierMacro.whereLargerImpl[T,A]
 
   def whereLargerOrEqual ( p : String, v : Any ) : Querier[T]
-    = where( p, v, Equal )
+    = where( p, v, LargerOrEqual )
 
   def whereLargerOrEqual[A] ( p : T with Persisted => A, v : A ) : Querier[T]
     = macro QuerierMacro.whereLargerOrEqualImpl[T,A]
 
   def whereSmaller ( p : String, v : Any ) : Querier[T]
-    = where( p, v, Equal )
+    = where( p, v, Smaller )
 
   def whereSmaller[A] ( p : T with Persisted => A, v : A ) : Querier[T]
     = macro QuerierMacro.whereSmallerImpl[T,A]
 
   def whereSmallerOrEqual ( p : String, v : Any ) : Querier[T]
-    = where( p, v, Equal )
+    = where( p, v, SmallerOrEqual )
 
   def whereSmallerOrEqual[A] ( p : T with Persisted => A, v : A ) : Querier[T]
     = macro QuerierMacro.whereSmallerOrEqualImpl[T,A]
 
   def whereLike ( p : String, v : Any ) : Querier[T]
-    = where( p, v, Equal )
+    = where( p, v, Like )
 
   def whereLike ( p : T with Persisted => String, v : String ) : Querier[T]
     = macro QuerierMacro.whereLikeImpl[T]
 
   def whereNotLike ( p : String, v : Any ) : Querier[T]
-    = where( p, v, Equal )
+    = where( p, v, NotLike )
 
   def whereNotLike ( p : T with Persisted => String, v : String ) : Querier[T]
     = macro QuerierMacro.whereNotLikeImpl[T]
 
   def whereIn ( p : String, v : Any ) : Querier[T]
-    = where( p, v, Equal )
+    = where( p, v, In )
 
   def whereIn[A] ( p : T with Persisted => A, v : Seq[A] ) : Querier[T]
     = macro QuerierMacro.whereInImpl[T,A]
 
   def whereNotIn ( p : String, v : Any ) : Querier[T]
-    = where( p, v, Equal )
+    = where( p, v, NotIn )
 
   def whereNotIn[A] ( p : T with Persisted => A, v : Seq[A] ) : Querier[T]
     = macro QuerierMacro.whereNotInImpl[T,A]

--- a/src/main/scala/sorm/Querier.scala
+++ b/src/main/scala/sorm/Querier.scala
@@ -241,8 +241,14 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
   def whereContains ( p : String, v : Any ) : Querier[T]
     = where( p, v, Contains )
 
+  def whereContains[A]( p : T with Persisted => Iterable[A], v : A) : Querier[T]
+    = macro QuerierMacro.whereContainsImpl[T,A]
+
   def whereNotContains ( p : String, v : Any ) : Querier[T]
     = where( p, v, NotContains )
+
+  def whereNotContains[A]( p : T with Persisted => Iterable[A], v : A) : Querier[T]
+  = macro QuerierMacro.whereNotContainsImpl[T,A]
 
   def whereConstitutes ( p : String, v : Any ) : Querier[T]
     = where( p, v, Constitutes )
@@ -253,9 +259,14 @@ class Querier [ T <: AnyRef : TypeTag ] ( query : Query, connector : Connector )
   def whereIncludes ( p : String, v : Any )  : Querier[T]
     = where( p, v, Includes )
 
+  def whereIncludes[A]( p : T with Persisted => Iterable[A], v : Iterable[A]) : Querier[T]
+    = macro QuerierMacro.whereIncludesImpl[T,A]
+
   def whereNotIncludes ( p : String, v : Any ) : Querier[T]
     = where( p, v, NotIncludes )
 
+  def whereNotIncludes[A]( p : T with Persisted => Iterable[A], v : Iterable[A]) : Querier[T]
+    = macro QuerierMacro.whereNotIncludesImpl[T,A]
 }
 object Querier {
   def apply [ T <: AnyRef : TypeTag ] ( mapping : EntityMapping, connector : Connector )

--- a/src/main/scala/sorm/macroimpl/QuerierMacro.scala
+++ b/src/main/scala/sorm/macroimpl/QuerierMacro.scala
@@ -1,0 +1,99 @@
+package sorm.macroimpl
+
+import scala.reflect.macros.blackbox.Context
+import scala.language.experimental.macros
+import sorm.Querier
+/**
+  * Created by takezoux2 on 2016/08/23.
+  */
+object QuerierMacro {
+  def whereEqualImpl[T <: AnyRef,A](c: Context)( p: c.Expr[T => A], v: c.Expr[A]) : c.Expr[Querier[T]] = {
+    whereImpl(c)("whereEqual", p, v)
+  }
+  def whereNotEqualImpl[T <: AnyRef,A](c: Context)( p: c.Expr[T => A], v: c.Expr[A]) : c.Expr[Querier[T]] = {
+    whereImpl(c)("whereNotEqual", p, v)
+  }
+  def whereLargerImpl[T <: AnyRef,A](c: Context)( p: c.Expr[T => A], v: c.Expr[A]) : c.Expr[Querier[T]] = {
+    whereImpl(c)("whereLarger", p, v)
+  }
+  def whereLargerOrEqualImpl[T <: AnyRef,A](c: Context)( p: c.Expr[T => A], v: c.Expr[A]) : c.Expr[Querier[T]] = {
+    whereImpl(c)("whereLargerOrEqual", p, v)
+  }
+  def whereSmallerImpl[T <: AnyRef,A](c: Context)( p: c.Expr[T => A], v: c.Expr[A]) : c.Expr[Querier[T]] = {
+    whereImpl(c)("whereSmaller", p, v)
+  }
+  def whereSmallerOrEqualImpl[T <: AnyRef,A](c: Context)( p: c.Expr[T => A], v: c.Expr[A]) : c.Expr[Querier[T]] = {
+    whereImpl(c)("whereSmallerOrEqual", p, v)
+  }
+  def whereLikeImpl[T <: AnyRef](c: Context)( p: c.Expr[T => String], v: c.Expr[String]) : c.Expr[Querier[T]] = {
+    whereImpl(c)("whereLike", p, v)
+  }
+  def whereNotLikeImpl[T <: AnyRef](c: Context)( p: c.Expr[T => String], v: c.Expr[String]) : c.Expr[Querier[T]] = {
+    whereImpl(c)("whereNotLike", p, v)
+  }
+  def whereInImpl[T <: AnyRef,A](c: Context)( p: c.Expr[T => A], v: c.Expr[Seq[A]]) : c.Expr[Querier[T]] = {
+    whereSeqImpl(c)("whereIn", p, v)
+  }
+  def whereNotInImpl[T <: AnyRef,A](c: Context)( p: c.Expr[T => A], v: c.Expr[Seq[A]]) : c.Expr[Querier[T]] = {
+    whereSeqImpl(c)("whereNotIn", p, v)
+  }
+
+  def whereRegexImpl[T <: AnyRef](c: Context)( p: c.Expr[T => String], v: c.Expr[String]) : c.Expr[Querier[T]] = {
+    whereImpl[T,String](c)("whereRegex", p, v)
+  }
+
+  def whereNotRegexImpl[T <: AnyRef](c: Context)( p: c.Expr[T => String], v: c.Expr[String]) : c.Expr[Querier[T]] = {
+    whereImpl[T,String](c)("whereNotRegex", p, v)
+  }
+
+  def whereImpl[T <: AnyRef,A](c: Context)(methodName: String, p: c.Expr[T => A], v: c.Expr[A]) : c.Expr[Querier[T]] = {
+    _whereImpl[T,A](c)(methodName,p,v,v.actualType)
+  }
+
+  def whereSeqImpl[T <: AnyRef,A](c: Context)(methodName: String, p: c.Expr[T => A], v: c.Expr[Seq[A]]) : c.Expr[Querier[T]] = {
+    _whereImpl[T,A](c)(methodName,p,v,v.actualType.typeArgs(0))
+  }
+
+
+  def _whereImpl[T <: AnyRef,A](c: Context)(methodName: String, p: c.Expr[T => A], v: c.Expr[Any], passedType: c.Type) : c.Expr[Querier[T]] = {
+    import c.universe._
+
+    // format check
+    val fieldName = p.tree match{
+      case Function(args,Select(ident,TermName(fieldName))) => {
+        fieldName
+      }
+      case _ => c.abort(c.enclosingPosition,"Field must be simple expression as such .whereEqual(_.userId, 2)")
+    }
+
+    // type check
+    val fieldType = p.actualType.typeArgs(1)
+    if(!(passedType <:< fieldType)){
+      // check convertable primitive type
+      if( ((passedType =:= typeOf[Int]) && (fieldType =:= typeOf[Long])) ||
+          ((passedType =:= typeOf[Float]) && (fieldType =:= typeOf[Double]))){
+        // OK
+      } else {
+        c.abort(c.enclosingPosition, s"Field:${fieldName} is ${fieldType} but passed ${passedType}")
+      }
+    }
+
+    //println(showRaw(field))
+    val tree = q"""${c.prefix}.${TermName(methodName)}(${fieldName},${v})"""
+    c.Expr[Querier[T]](tree)
+  }
+
+  def orderByImpl[T <: AnyRef](c: Context)( p: c.Expr[T => Any], reverse: c.Expr[Boolean]) : c.Expr[Querier[T]] = {
+    import c.universe._
+
+    //println(showRaw(field))
+    val tree = p.tree match{
+      case Function(args,Select(ident,TermName(field))) => {
+        q"""${c.prefix}.order(${field},${reverse})"""
+      }
+      case _ => c.abort(c.enclosingPosition,"Field must be simple expression as such .whereEqual(_.userId,2)")
+    }
+    c.Expr[Querier[T]](tree)
+  }
+
+}


### PR DESCRIPTION
Add type safe query by macro.

* Can avoid field name typo
* Can check value type at compile time
* No overhead at run time

Usage
```scala
// model class
case class User(name: String, age: Int)
```

```scala
// Standard way
DB.query[User].whereEquals("id", 1).whereIn("name", Seq("tom")).fetchOne

// Using type safe wheres
DB.query[User].whereEquals(_.id, 1).whereIn(_.name, Seq("tom")).fetchOne
```

I built by scala 2.11.8.
