### PR TITLE
Preliminary, work-in-progress SQLite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For more info, tutorials and documentation please visit the [official site](http
 * H2
 * HSQLDB
 * Oracle (experimental)
+* SQLite (experimental)
 
 ##Supported Scala versions
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>3.8.11.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.11</artifactId>
       <version>2.2.3</version>

--- a/src/main/scala/sorm/core/Connector.scala
+++ b/src/main/scala/sorm/core/Connector.scala
@@ -21,6 +21,7 @@ class Connector (url: String, user: String, password: String, poolSize: Int, tim
         case DbType.Hsqldb => new Hsqldb(jdbcConnection)
         case DbType.Postgres => new Postgres(jdbcConnection)
         case DbType.Oracle => new Oracle(jdbcConnection)
+        case DbType.Sqlite => new Sqlite(jdbcConnection)
         case _ => ???
       }
   

--- a/src/main/scala/sorm/driver/Sqlite.scala
+++ b/src/main/scala/sorm/driver/Sqlite.scala
@@ -1,0 +1,59 @@
+package sorm.driver
+
+import sorm._, ddl._, jdbc._
+import sext._, embrace._
+import sql.Sql
+
+class Sqlite (protected val connection : JdbcConnection)
+  extends DriverConnection
+    with StdConnection
+    with StdTransaction
+    with StdAbstractSqlToSql
+    with StdQuote
+    with StdSqlRendering
+    with StdStatement
+    with StdQuery
+    with StdModify
+    with StdCreateTable
+    with StdListTables
+    with StdDropTables
+    with StdDropAllTables
+    with StdNow
+{
+
+  override protected def showTablesSql
+  = "SELECT TBL_NAME FROM SQLITE_MASTER WHERE TYPE = 'table'"
+
+  override protected def tableDdl ( t : Table ) : String
+  = {
+    val Table(name, columns, primaryKeyStream, uniqueKeys, indexes, foreingKeys) = t
+    val primaryKey = primaryKeyStream.toSet
+    val statements =
+      ( columns.map(columnDdl) ++:
+        primaryKey.toList.map(
+          name => (name, columns.find(_.name == name).get.autoIncrement)
+        ).$(primaryKeyAndIncrementDdl) +:
+        indexes.map(indexDdl).filter(_.nonEmpty) ++:
+        uniqueKeys.map(uniqueKeyDdl) ++:
+        foreingKeys.map(foreingKeyDdl).toStream
+        ) .filter(_.nonEmpty)
+
+    "CREATE TABLE " + quote(name) +
+      ( "\n( " + statements.mkString(",\n").indent(2).trim + " )" ).indent(2)
+  }
+
+  protected def primaryKeyAndIncrementDdl ( columns : Seq[(String, Boolean)] )
+  = "PRIMARY KEY (" + columns.view.map {
+    case (name, isIncrement) => quote(name) + isIncrement.option(" AUTOINCREMENT ").getOrElse("")
+  }.mkString(", ") + ")"
+
+  override protected def columnDdl ( c : Column )
+  = quote(c.name) + " " + columnTypeDdl(c.autoIncrement.option(ColumnType.Integer).getOrElse(c.t)) +
+    c.nullable.option(" NULL").getOrElse(" NOT NULL")
+
+  override def insertAndGetGeneratedKeys( table : String, values : Iterable[(String, Any)] ) : Seq[Any] =
+    super.insertAndGetGeneratedKeys(table, values).map {
+      case _id: Long => _id
+      case _id: Int => _id.toLong
+    }
+}

--- a/src/main/scala/sorm/jdbc/JdbcConnection.scala
+++ b/src/main/scala/sorm/jdbc/JdbcConnection.scala
@@ -89,7 +89,7 @@ class JdbcConnection( protected val connection : Connection ) extends Transactio
       }
     }
 
-  private def preparedStatement
+  protected def preparedStatement
     ( stmt : Statement,
       generatedKeys : Boolean = false )
     = {
@@ -106,6 +106,8 @@ class JdbcConnection( protected val connection : Connection ) extends Transactio
 
       s
     }
+
+  def getConnection() = connection
 
   def close() = connection.close()
 }

--- a/src/test/scala/sorm/test/MultiInstanceSuite.scala
+++ b/src/test/scala/sorm/test/MultiInstanceSuite.scala
@@ -8,7 +8,7 @@ trait MultiInstanceSuite extends Suite with BeforeAndAfterAll with SequentialNes
 
   def entities : Traversable[Entity]
   def poolSizes = 1 :: 6 :: Nil
-  def dbTypes = DbType.H2 :: DbType.Mysql :: DbType.Hsqldb :: DbType.Postgres :: Nil
+  def dbTypes = DbType.H2 :: DbType.Mysql :: DbType.Hsqldb :: DbType.Postgres :: DbType.Sqlite :: Nil
   lazy val instancesAndIds = TestingInstances.instances( entities, poolSizes, dbTypes )
 
   override protected def afterAll() {

--- a/src/test/scala/sorm/test/TestingInstances.scala
+++ b/src/test/scala/sorm/test/TestingInstances.scala
@@ -42,7 +42,7 @@ object TestingInstances {
   def instances
     ( entities : Traversable[Entity],
       poolSizes : Seq[Int] = 1 :: 6 :: Nil,
-      dbTypes : Seq[DbType] = DbType.H2 :: DbType.Mysql :: DbType.Hsqldb :: DbType.Postgres :: Nil )
+      dbTypes : Seq[DbType] = DbType.H2 :: DbType.Mysql :: DbType.Hsqldb :: DbType.Postgres :: DbType.Sqlite :: Nil )
     : Stream[(Instance, String)]
     = dbTypes.toStream.flatMap(t => poolSizes.map(t -> _))
         .map{ case (t, s) => instance(entities, t, s) -> (name(t) + ":" + s) }

--- a/src/test/scala/sorm/test/general/FieldTestSuite1.scala
+++ b/src/test/scala/sorm/test/general/FieldTestSuite1.scala
@@ -33,6 +33,7 @@ class FieldTestSuite1 extends FunSuite with ShouldMatchers with SequentialNested
   test("H2 initialization") { instance(DbType.H2).close() }
   test("MySQL initialization") { instance(DbType.Mysql).close() }
   test("Oracle initialization") { instance(DbType.Oracle).close() }
+  test("SQLite initialization") { instance(DbType.Sqlite).close() }
 
 }
 object FieldTestSuite1 {


### PR DESCRIPTION
While I thought that development of SORM might be inactive, some recent commits have proven the opposite, so I'd like to propose another addition ...
I'm using SORM and I'm quite happy with it, but I would prefer to use SQLite over other embedded databases, as SQLite interoperability with other languages is much easier than e.g. H2.

Thus I've looked into adding SQLite support to SORM.

The patch so far passes many tests, however still has some weak spots:
- Some errors in DateTime (de)serialization, might be similar to problems described [here](https://bitbucket.org/xerial/sqlite-jdbc/issues/23/getdate-returns-wrong-values), apparently dates can be stored in different ways in SQLite, but the JDBC adapter only understands one ...
- Missing RegEx functionality. SQLite has no built-in regex engine, however, it could be added by using a user defined function, one would need to circumvent c3p0 to get a real SQLite connection object ...
- Concurrency problems ... somehow puzzle me as SQLite by itself tend to handle concurrency really well, maybe some default options lead to overzealous locking …

I'm putting it here, as I guess it might already be in a state where it might be useful to others, and furthermore, some problems (like the DateTime serialization issue) might be much easier fixed if someone with more in-depth knowledge to SORM might take a look at it.

What do you think? I'll further take a look at the problems, but I'd be really happy if someone can point me to the right points; and afterwards this new database support could get added.

Best regards,
Christian