### PR TITLE
Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 scala:
   - 2.10.4
   - 2.11.5
+  - 2.12.0
 before_script:
   - psql -c 'create database test;' -U postgres
   - mysql -e 'create database sorm_test;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
+jdk:
+  - oraclejdk8
 scala:
-  - 2.10.4
-  - 2.11.5
   - 2.12.0
 before_script:
   - psql -c 'create database test;' -U postgres

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For more info, tutorials and documentation please visit the [official site](http
 
 ##Supported Scala versions
 
-2.10, 2.11
+2.10, 2.11, 2.12
 
 ##Maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
-      <version>0.9.2-pre5</version>
+      <version>0.9.2.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.nikita-volkov</groupId>
@@ -79,7 +79,7 @@
     </dependency>
     <dependency>
       <groupId>com.typesafe.scala-logging</groupId>
-      <artifactId>scala-logging_2.11</artifactId>
+      <artifactId>scala-logging_${scalaVersion}</artifactId>
       <version>[3.4.0,4)</version>
     </dependency>
     <dependency>
@@ -115,8 +115,8 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.11</artifactId>
-      <version>2.2.3</version>
+      <artifactId>scalatest_${scalaVersion}</artifactId>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -128,17 +128,17 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
-      <version>[2.10,2.11.999)</version>
+      <version>[2.10,2.12.999)</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>[2.10,2.11.999)</version>
+      <version>[2.10,2.12.999)</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
-      <version>[2.10,2.11.999)</version>
+      <version>[2.10,2.12.999)</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     </dependency>
     <dependency>
       <groupId>com.typesafe.scala-logging</groupId>
-      <artifactId>scala-logging_${scalaVersion}</artifactId>
+      <artifactId>scala-logging_2.12</artifactId>
       <version>[3.4.0,4)</version>
     </dependency>
     <dependency>
@@ -115,7 +115,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scalaVersion}</artifactId>
+      <artifactId>scalatest_2.12</artifactId>
       <version>3.0.1</version>
       <scope>test</scope>
     </dependency>

--- a/src/test/scala/sorm/core/PathSuite.scala
+++ b/src/test/scala/sorm/core/PathSuite.scala
@@ -14,13 +14,13 @@ class PathSuite extends FunSuite with Matchers {
     pending
   }
   test("pathAndRemainder braced parsing"){
-    partAndRemainder("(asdf)") should be === (Part.Braced("asdf"), "")
-    partAndRemainder("(asdf).sdf") should be === (Part.Braced("asdf"), ".sdf")
-    partAndRemainder("(342).sdf") should be === (Part.Braced("342"), ".sdf")
+    partAndRemainder("(asdf)") should equal (Part.Braced("asdf"), "")
+    partAndRemainder("(asdf).sdf") should equal (Part.Braced("asdf"), ".sdf")
+    partAndRemainder("(342).sdf") should equal (Part.Braced("342"), ".sdf")
   }
   test("pathAndRemainder dotted parsing"){
-    partAndRemainder("sdf") should be === (Part.Dotted("sdf"), "")
-    partAndRemainder("sdf.dksfje") should be === (Part.Dotted("sdf"), ".dksfje")
-    partAndRemainder(".sdf.dksfje") should be === (Part.Dotted("sdf"), ".dksfje")
+    partAndRemainder("sdf") should equal (Part.Dotted("sdf"), "")
+    partAndRemainder("sdf.dksfje") should equal (Part.Dotted("sdf"), ".dksfje")
+    partAndRemainder(".sdf.dksfje") should equal (Part.Dotted("sdf"), ".dksfje")
   }
 }

--- a/src/test/scala/sorm/core/PathSuite.scala
+++ b/src/test/scala/sorm/core/PathSuite.scala
@@ -1,13 +1,12 @@
 package sorm.core
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 
 @RunWith(classOf[JUnitRunner])
-class PathSuite extends FunSuite with ShouldMatchers {
+class PathSuite extends FunSuite with Matchers {
   
   import Path._
   

--- a/src/test/scala/sorm/core/PathSuite.scala
+++ b/src/test/scala/sorm/core/PathSuite.scala
@@ -1,6 +1,6 @@
 package sorm.core
 
-import org.scalatest._
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 

--- a/src/test/scala/sorm/joda/ExtensionsTest.scala
+++ b/src/test/scala/sorm/joda/ExtensionsTest.scala
@@ -1,12 +1,12 @@
 package sorm.joda
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class ExtensionsTest extends FunSuite with ShouldMatchers {
+class ExtensionsTest extends FunSuite with Matchers {
   import Extensions._
   import org.joda.time._
 

--- a/src/test/scala/sorm/persisted/PersistedSuite.scala
+++ b/src/test/scala/sorm/persisted/PersistedSuite.scala
@@ -1,14 +1,13 @@
 package sorm.persisted
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import sorm.persisted.PersistedSuite._
 import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 import sorm._
 
 @RunWith(classOf[JUnitRunner])
-class PersistedSuite extends FunSuite with ShouldMatchers {
+class PersistedSuite extends FunSuite with Matchers {
 
   test("Different persisted ids make otherwise equaling objects have different hashcodes") {
     Persisted(Genre("a"), 1).hashCode should not equal(Persisted(Genre("a"), 2).hashCode)
@@ -59,12 +58,15 @@ class PersistedSuite extends FunSuite with ShouldMatchers {
     )
   }
   test("dynamic persisted fails on incorrect map") {
-    evaluating {Persisted[Artist](Map("name" -> "Nirvana"), 35)} should produce[Exception]
+    intercept[Exception] {
+      Persisted[Artist](Map("name" -> "Nirvana"), 35)
+    }
   }
   test("persisted on persisted") {
-    evaluating { Persisted(Persisted(Artist("Nirvana", Set()), 2), 4) }
-      .should( produce[Exception])
-      .getMessage should be ("Persisted on persisted called")
+    val thrown = intercept[Exception] {
+      Persisted(Persisted(Artist("Nirvana", Set()), 2), 4)
+    }
+    thrown.getMessage should be ("Persisted on persisted called")
   }
 }
 object PersistedSuite {

--- a/src/test/scala/sorm/reflection/ReflectionSuite.scala
+++ b/src/test/scala/sorm/reflection/ReflectionSuite.scala
@@ -1,12 +1,11 @@
 package sorm.reflection
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class ReflectionSuite extends FunSuite with ShouldMatchers {
+class ReflectionSuite extends FunSuite with Matchers {
   import ReflectionSuite._
 
 //  from mirrorquirks

--- a/src/test/scala/sorm/reflection/ReflectionSuite.scala
+++ b/src/test/scala/sorm/reflection/ReflectionSuite.scala
@@ -24,17 +24,17 @@ class ReflectionSuite extends FunSuite with Matchers {
 //    be("sorm.mirrorQuirks.MirrorQuirksTest.NestedClasses#NestedClass#DeeplyNestedClass")
 //  }
 //  test("name of type with mixin") {
-//    name(tag[Artist with Mixin].sym) should equal(name(tag[Artist].sym))
+//    name(tag[Artist with Mixin].sym) shouldEqual(name(tag[Artist].sym))
 //  }
 //  test("properties of types with mixins") {
 //    println(tag[Artist with Mixin].tpe.kind)
 //    println(tag[Artist].tpe.kind)
 //    println(isMixedIn(tag[Artist with Mixin].tpe))
-//    properties(tag[Artist with Mixin].tpe) should equal (properties(tag[Artist].tpe))
+//    properties(tag[Artist with Mixin].tpe) shouldEqual (properties(tag[Artist].tpe))
 //  }
   test("propertyValue of Persisted"){
     import sorm.persisted._
-    Reflection[Genre].propertyValue("name", Persisted(Genre("A"), 1)) should equal ("A")
+    Reflection[Genre].propertyValue("name", Persisted(Genre("A"), 1)) shouldEqual ("A")
   }
   test("Generics have effect on hashCode"){
     Reflection[Seq[Int]].hashCode should not equal(Reflection[Seq[Any]].hashCode)
@@ -53,17 +53,17 @@ class ReflectionSuite extends FunSuite with Matchers {
     )
   }
   test("Reflections on same type must be identical"){
-    Reflection[String] should equal (Reflection[String])
-    Reflection[Seq[String]] should equal (Reflection[Seq[String]])
+    Reflection[String] shouldEqual (Reflection[String])
+    Reflection[Seq[String]] shouldEqual (Reflection[Seq[String]])
   }
   test("Reflection extending type must not equal it's ancestor"){
     Reflection[String] should not equal (Reflection[Any])
   }
   test("Int inheritance"){
-    (Reflection[Int] <:< Reflection[AnyVal]) should equal (true)
-    (Reflection[Int] <:< Reflection[Any]) should equal (true)
-    (Reflection[Int] <:< Reflection[Int]) should equal (true)
-    (Reflection[Int] <:< Reflection[AnyRef]) should equal (false)
+    (Reflection[Int] <:< Reflection[AnyVal]) shouldEqual (true)
+    (Reflection[Int] <:< Reflection[Any]) shouldEqual (true)
+    (Reflection[Int] <:< Reflection[Int]) shouldEqual (true)
+    (Reflection[Int] <:< Reflection[AnyRef]) shouldEqual (false)
   }
   test("String inheritance"){
     assert( Reflection[String] <:< Reflection[Any] )
@@ -86,7 +86,7 @@ class ReflectionSuite extends FunSuite with Matchers {
   test("property value") {
     val artist = Artist(234, "Nirvana", Set(Genre("Grunge"), Genre("Rock")), Set("kurt-cobain", "grunge", "nirvana"))
 
-    Reflection[Artist].propertyValue("name", artist) should equal("Nirvana")
+    Reflection[Artist].propertyValue("name", artist) shouldEqual("Nirvana")
   }
   test("signature of class with non-Predef generics") {
     Reflection[collection.mutable.Map[collection.mutable.HashSet[String], Int]].signature should
@@ -101,7 +101,7 @@ class ReflectionSuite extends FunSuite with Matchers {
     equal("Seq[_]")
   }
   test("String signature"){
-    Reflection[String].signature should be === "String"
+    Reflection[String].signature shouldEqual "String"
   }
   test("signature of class with no generics") {
     Reflection[Int].signature should

--- a/src/test/scala/sorm/reflection/ScalaApiSuite.scala
+++ b/src/test/scala/sorm/reflection/ScalaApiSuite.scala
@@ -1,12 +1,11 @@
 package sorm.reflection
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class ScalaApiSuite extends FunSuite with ShouldMatchers {
+class ScalaApiSuite extends FunSuite with Matchers {
   import ScalaApiSuite._
 
   import reflect.runtime.universe._

--- a/src/test/scala/sorm/tableSorters/DropTest.scala
+++ b/src/test/scala/sorm/tableSorters/DropTest.scala
@@ -6,13 +6,12 @@ import mappings._
 import sext._, embrace._
 import util.Random
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class DropTest extends FunSuite with ShouldMatchers {
+class DropTest extends FunSuite with Matchers {
 
 
   import samples.ArtistModel._

--- a/src/test/scala/sorm/test/TestingInstancesSuite.scala
+++ b/src/test/scala/sorm/test/TestingInstancesSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -9,7 +8,7 @@ import sorm._
 import core.DbType
 
 @RunWith(classOf[JUnitRunner])
-class TestingInstancesSuite extends FunSuite with ShouldMatchers {
+class TestingInstancesSuite extends FunSuite with Matchers {
   import TestingInstancesSuite._
 
   test("Sequentially accessing instances gets them cleaned up") {

--- a/src/test/scala/sorm/test/features/CurrentDateTimeTest.scala
+++ b/src/test/scala/sorm/test/features/CurrentDateTimeTest.scala
@@ -1,7 +1,6 @@
 package sorm.test.features
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sext._, embrace._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class CurrentDateTimeTest extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class CurrentDateTimeTest extends FunSuite with Matchers with MultiInstanceSuite {
   
   def entities = Set()
   instancesAndIds foreach { case (db, dbId) =>

--- a/src/test/scala/sorm/test/features/FetchWithSqlSuite.scala
+++ b/src/test/scala/sorm/test/features/FetchWithSqlSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.features
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sext._, embrace._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class FetchWithSqlSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class FetchWithSqlSuite extends FunSuite with Matchers with MultiInstanceSuite {
 
   import FetchWithSqlSuite._
 

--- a/src/test/scala/sorm/test/features/InFilterTest.scala
+++ b/src/test/scala/sorm/test/features/InFilterTest.scala
@@ -1,7 +1,6 @@
 package sorm.test.features
 
-import org.scalatest.{BeforeAndAfterAll, FunSuite}
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -9,7 +8,7 @@ import sorm._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class InFilterTest extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class InFilterTest extends FunSuite with Matchers with MultiInstanceSuite {
   import InFilterTest._
 
   def entities = Set() + Entity[A]()

--- a/src/test/scala/sorm/test/features/MultiConnectionSupportSuite.scala
+++ b/src/test/scala/sorm/test/features/MultiConnectionSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.features
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -14,7 +13,7 @@ object MultiConnectionSupportSuite {
   case class A ( a : Int )
 }
 @RunWith(classOf[JUnitRunner])
-class MultiConnectionSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class MultiConnectionSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import MultiConnectionSupportSuite._
 
   override def entities = Entity[A]() :: Nil

--- a/src/test/scala/sorm/test/features/MultithreadingTest.scala
+++ b/src/test/scala/sorm/test/features/MultithreadingTest.scala
@@ -1,7 +1,6 @@
 package sorm.test.features
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -12,7 +11,7 @@ object MultithreadingTest {
   case class A (a : Int)
 }
 @RunWith(classOf[JUnitRunner])
-class MultithreadingTest extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class MultithreadingTest extends FunSuite with Matchers with MultiInstanceSuite {
   import MultithreadingTest._
 
   def entities =  Set() + Entity[A]()

--- a/src/test/scala/sorm/test/features/OrderBySuite.scala
+++ b/src/test/scala/sorm/test/features/OrderBySuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.features
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sext._, embrace._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class OrderBySuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class OrderBySuite extends FunSuite with Matchers with MultiInstanceSuite {
   import OrderBySuite._
   
   def entities = Set(Entity[A]())

--- a/src/test/scala/sorm/test/features/ParallelSuite.scala
+++ b/src/test/scala/sorm/test/features/ParallelSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.features
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sorm._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class ParallelSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class ParallelSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import ParallelSuite._
 
   def entities = Set(Entity[A]())

--- a/src/test/scala/sorm/test/features/RegexTest.scala
+++ b/src/test/scala/sorm/test/features/RegexTest.scala
@@ -7,7 +7,7 @@ import sorm.core.DbType
 import sorm.test.MultiInstanceSuite
 
 @org.junit.runner.RunWith(classOf[junit.JUnitRunner])
-class RegexTest extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class RegexTest extends FunSuite with Matchers with MultiInstanceSuite {
 
   def entities = Set() + Entity[User]()
   override def dbTypes = DbType.H2 :: DbType.Mysql :: DbType.Postgres :: Nil

--- a/src/test/scala/sorm/test/features/SormValidationSuite.scala
+++ b/src/test/scala/sorm/test/features/SormValidationSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.features
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,53 +9,53 @@ import samples._
 import sorm.{Entity, Instance}
 
 @RunWith(classOf[JUnitRunner])
-class SormValidationSuite extends FunSuite with ShouldMatchers {
+class SormValidationSuite extends FunSuite with Matchers {
   import SormValidationSuite._
 
   test("Mutually recursive types are not supported"){
-    evaluating {
+    intercept[Instance.ValidationException] {
       new Instance(
         Entity[F]() :: Entity[G]() :: Nil,
         "jdbc:h2:mem:test",
         initMode = InitMode.DropAllCreate
       ).close()
-    } should produce [Instance.ValidationException]
+    }
   }
   test("Mutually recursive types are not supported - deep"){
-    evaluating {
+    intercept[Instance.ValidationException] {
       new Instance(
         Entity[F]() :: Entity[H]() :: Nil,
         "jdbc:h2:mem:test",
         initMode = InitMode.DropAllCreate
       ).close()
-    } should produce [Instance.ValidationException]
+    }
   }
   test("Recursive types are not supported"){
-    evaluating {
+    intercept[Instance.ValidationException] {
       new Instance(
         Entity[E]() :: Nil,
         "jdbc:h2:mem:test",
         initMode = InitMode.DropAllCreate
       ).close()
-    } should produce [Instance.ValidationException]
+    }
   }
   test("`Any` type is not supported"){
-    evaluating {
+    intercept[Instance.ValidationException] {
       new Instance(
         Entity[D]() :: Nil,
         "jdbc:h2:mem:test",
         initMode = InitMode.DropAllCreate
       ).close()
-    } should produce [Instance.ValidationException]
+    }
   }
   test("referred entities validation"){
-    evaluating {
+    intercept[Instance.ValidationException] {
       new Instance(
         Entity[A]() :: Nil,
         "jdbc:h2:mem:test",
       initMode = InitMode.DropAllCreate
       ).close()
-    } should produce [Instance.ValidationException]
+    }
   }
   test("Correct instantiation doesn't throw exceptions"){
     new Instance(

--- a/src/test/scala/sorm/test/general/ArtistDbSuite.scala
+++ b/src/test/scala/sorm/test/general/ArtistDbSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.general
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -23,7 +22,7 @@ object ArtistDbSuite {
 
 }
 @RunWith(classOf[JUnitRunner])
-class ArtistDbSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class ArtistDbSuite extends FunSuite with Matchers with MultiInstanceSuite {
 
   import ArtistDbSuite._
 

--- a/src/test/scala/sorm/test/general/ArtistDbSuite.scala
+++ b/src/test/scala/sorm/test/general/ArtistDbSuite.scala
@@ -83,7 +83,7 @@ class ArtistDbSuite extends FunSuite with Matchers with MultiInstanceSuite {
         .whereEqual("names.value(1)", "Rolling Stones")
         .fetchOne()
         .get
-        .names(en)(1) should be === "Rolling Stones"
+        .names(en)(1) shouldEqual "Rolling Stones"
     }
     test(dbId + " - Offset"){
       pending
@@ -92,7 +92,7 @@ class ArtistDbSuite extends FunSuite with Matchers with MultiInstanceSuite {
       pending
     }
     test(dbId + " - Ordering"){
-      db.query[Artist].order("id", true).fetch().map(_.id) should equal (godsmack.id :: direStraits.id :: rollingStones.id :: kino.id :: nirvana.id :: metallica.id :: Nil)
+      db.query[Artist].order("id", true).fetch().map(_.id) shouldEqual (godsmack.id :: direStraits.id :: rollingStones.id :: kino.id :: nirvana.id :: metallica.id :: Nil)
     }
     test(dbId + " - Contains"){
       pending
@@ -105,14 +105,14 @@ class ArtistDbSuite extends FunSuite with Matchers with MultiInstanceSuite {
         .whereEqual("styles.item", metal)
         .fetch()
         .flatMap{_.names.values.head}
-        .toSet should be === Set("Metallica", "Godsmack")
+        .toSet shouldEqual Set("Metallica", "Godsmack")
     }
     test(dbId + " - Map, Set, Seq deep path"){
       db.query[Artist]
         .whereEqual("styles.item.names.value.item", "Hard Rock")
         .fetch()
         .flatMap{_.names.values.head}
-        .toSet should be === Set("Metallica", "Nirvana", "Godsmack")
+        .toSet shouldEqual Set("Metallica", "Nirvana", "Godsmack")
     }
     test(dbId + " - Results have correct id property"){
       pending
@@ -120,13 +120,13 @@ class ArtistDbSuite extends FunSuite with Matchers with MultiInstanceSuite {
       // assumption of the test is invalid: A database does not necessarily
       // have to return data in the order that they were inserted, and the
       // query does not include an ORDER BY clause.
-      // db.query[Artist].fetchOne().map{_.id} should be === Some(metallica.id)
+      // db.query[Artist].fetchOne().map{_.id} shouldEqual Some(metallica.id)
     }
     test(dbId + " - Query by id"){
       db.query[Artist].whereEqual("id", metallica.id).fetchOne()
-        .map{_.names.values.head.head}.get should be === "Metallica"
+        .map{_.names.values.head.head}.get shouldEqual "Metallica"
       db.query[Artist].whereEqual("id", kino.id).fetchOne()
-        .map{_.names.values.head.head}.get should be === "Kino"
+        .map{_.names.values.head.head}.get shouldEqual "Kino"
     }
   }
 }

--- a/src/test/scala/sorm/test/general/EntityReferredSeveralTimesSuite.scala
+++ b/src/test/scala/sorm/test/general/EntityReferredSeveralTimesSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.general
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sext._, embrace._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class EntityReferredSeveralTimesSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class EntityReferredSeveralTimesSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import EntityReferredSeveralTimesSuite._
 
   def entities = Set() + Entity[A]() + Entity[B]()

--- a/src/test/scala/sorm/test/general/EntityWithNoPrimitivesSuite.scala
+++ b/src/test/scala/sorm/test/general/EntityWithNoPrimitivesSuite.scala
@@ -4,7 +4,7 @@ import sorm._
 import org.scalatest._
 
 @org.junit.runner.RunWith(classOf[junit.JUnitRunner])
-class EntityWithNoPrimitivesSuite extends FunSuite with ShouldMatchers {
+class EntityWithNoPrimitivesSuite extends FunSuite with Matchers {
   import EntityWithNoPrimitivesSuite._
 
   test("All is fine"){

--- a/src/test/scala/sorm/test/general/FieldTestSuite1.scala
+++ b/src/test/scala/sorm/test/general/FieldTestSuite1.scala
@@ -1,7 +1,6 @@
 package sorm.test.general
 
-import org.scalatest.{SequentialNestedSuiteExecution, FunSuite}
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{SequentialNestedSuiteExecution, FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -12,7 +11,7 @@ import org.joda.time._
 import sorm.test.TestingInstances
 
 @RunWith(classOf[JUnitRunner])
-class FieldTestSuite1 extends FunSuite with ShouldMatchers with SequentialNestedSuiteExecution {
+class FieldTestSuite1 extends FunSuite with Matchers with SequentialNestedSuiteExecution {
   import FieldTestSuite1._
   def entities
     = Set() +

--- a/src/test/scala/sorm/test/general/TutorialSuite.scala
+++ b/src/test/scala/sorm/test/general/TutorialSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.general
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -9,7 +8,7 @@ import sorm._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class TutorialSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class TutorialSuite extends FunSuite with Matchers with MultiInstanceSuite {
 
   import TutorialSuite._
 

--- a/src/test/scala/sorm/test/issues/Issue40Test.scala
+++ b/src/test/scala/sorm/test/issues/Issue40Test.scala
@@ -3,7 +3,7 @@ package sorm.test.issues
 import org.scalatest._
 
 @org.junit.runner.RunWith(classOf[junit.JUnitRunner])
-class Issue40Test extends FunSuite with ShouldMatchers {
+class Issue40Test extends FunSuite with Matchers {
   import sorm._
   import Issue40Test._
 

--- a/src/test/scala/sorm/test/types/BigDecimalSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/BigDecimalSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -15,7 +14,7 @@ object BigDecimalSupportSuite {
 }
 
 @RunWith(classOf[JUnitRunner])
-class BigDecimalSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class BigDecimalSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import BigDecimalSupportSuite._
 
   def entities = Set(Entity[A]())

--- a/src/test/scala/sorm/test/types/BooleanSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/BooleanSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sorm._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class BooleanSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class BooleanSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import BooleanSupportSuite._
 
   def entities = Set(Entity[A]())

--- a/src/test/scala/sorm/test/types/DateTimeSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/DateTimeSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -13,7 +12,7 @@ import org.joda.time.DateTime
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class DateTimeSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class DateTimeSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import DateTimeSupportSuite._
 
   def entities = Set() + Entity[A]()

--- a/src/test/scala/sorm/test/types/DoubleSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/DoubleSupportSuite.scala
@@ -4,7 +4,7 @@ import org.scalatest._
 import sorm._, test._
 
 @org.junit.runner.RunWith(classOf[junit.JUnitRunner])
-class DoubleSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class DoubleSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import DoubleSupportSuite._
 
   def entities = Set(Entity[A]())

--- a/src/test/scala/sorm/test/types/EnumSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/EnumSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.{SequentialNestedSuiteExecution, FunSuite}
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{SequentialNestedSuiteExecution, FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sext._, embrace._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class EnumSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class EnumSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import EnumSupportSuite._
 
   def entities = Set() + Entity[A]()

--- a/src/test/scala/sorm/test/types/OptionEntitySeqItemSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/OptionEntitySeqItemSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sext._, embrace._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class OptionEntitySeqItemSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class OptionEntitySeqItemSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
 
   import OptionEntitySeqItemSupportSuite._
 

--- a/src/test/scala/sorm/test/types/OptionEntitySeqItemSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/OptionEntitySeqItemSupportSuite.scala
@@ -24,14 +24,14 @@ class OptionEntitySeqItemSupportSuite extends FunSuite with Matchers with MultiI
     val a4 = db.save(A( Seq(None) ))
 
     test(dbId + " - empty seq"){
-      db.fetchById[A](a1.id).seq should be === Seq()
+      db.fetchById[A](a1.id).seq shouldEqual Seq()
     }
     test(dbId + " - seq of none"){
-      db.fetchById[A](a4.id).seq should be === Seq(None)
+      db.fetchById[A](a4.id).seq shouldEqual Seq(None)
     }
     test(dbId + " - not empty seqs are correct"){
-      db.fetchById[A](a2.id).seq should be === Seq(Some(b1), None, Some(b2))
-      db.fetchById[A](a3.id).seq should be === Seq(None, Some(b2))
+      db.fetchById[A](a2.id).seq shouldEqual Seq(Some(b1), None, Some(b2))
+      db.fetchById[A](a3.id).seq shouldEqual Seq(None, Some(b2))
     }
   }
 }

--- a/src/test/scala/sorm/test/types/OptionEntitySupportSuite.scala
+++ b/src/test/scala/sorm/test/types/OptionEntitySupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sext._, embrace._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class OptionEntitySupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class OptionEntitySupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import OptionEntitySupportSuite._
 
   def entities = Entity[A]() :: Entity[B]() :: Nil

--- a/src/test/scala/sorm/test/types/OptionSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/OptionSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sext._, embrace._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class OptionSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class OptionSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import OptionSupportSuite._
 
   def entities = Entity[EntityWithOptionInOption]() :: Nil

--- a/src/test/scala/sorm/test/types/OptionTupleSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/OptionTupleSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sext._, embrace._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class OptionTupleSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class OptionTupleSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
 
   import OptionTupleSupportSuite._
 

--- a/src/test/scala/sorm/test/types/OptionTupleSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/OptionTupleSupportSuite.scala
@@ -20,13 +20,13 @@ class OptionTupleSupportSuite extends FunSuite with Matchers with MultiInstanceS
     val a3 = db.save(A( Some(56 -> Some("asdf")) ))
 
     test(dbId + " - top none"){
-      db.fetchById[A](a1.id).a should be === None
+      db.fetchById[A](a1.id).a shouldEqual None
     }
     test(dbId + " - deep none"){
-      db.fetchById[A](a2.id).a should be === Some(2 -> None)
+      db.fetchById[A](a2.id).a shouldEqual Some(2 -> None)
     }
     test(dbId + " - deep some"){
-      db.fetchById[A](a3.id).a should be === Some(56 -> Some("asdf"))
+      db.fetchById[A](a3.id).a shouldEqual Some(56 -> Some("asdf"))
     }
   }
 

--- a/src/test/scala/sorm/test/types/OptionValueSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/OptionValueSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -10,7 +9,7 @@ import sext._, embrace._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class OptionValueSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class OptionValueSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
 
   import OptionValueSupportSuite._
 

--- a/src/test/scala/sorm/test/types/OptionValueSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/OptionValueSupportSuite.scala
@@ -20,15 +20,15 @@ class OptionValueSupportSuite extends FunSuite with Matchers with MultiInstanceS
     val a3 = db.save(A(Some(7)))
 
     test(dbId + " - saved entities are correct"){
-      db.fetchById[A](a1.id).a should be === None
-      db.fetchById[A](a2.id).a should be === Some(3)
-      db.fetchById[A](a3.id).a should be === Some(7)
+      db.fetchById[A](a1.id).a shouldEqual None
+      db.fetchById[A](a2.id).a shouldEqual Some(3)
+      db.fetchById[A](a3.id).a shouldEqual Some(7)
     }
     test(dbId + " - equals filter"){
       db.query[A]
-        .whereEqual("a", None).fetchOne().get should be === a1
+        .whereEqual("a", None).fetchOne().get shouldEqual a1
       db.query[A]
-        .whereEqual("a", Some(3)).fetchOne().get should be === a2
+        .whereEqual("a", Some(3)).fetchOne().get shouldEqual a2
     }
     test(dbId + " - not equals filter"){
       db.query[A]

--- a/src/test/scala/sorm/test/types/RangeSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/RangeSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -9,7 +8,7 @@ import sorm._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class RangeSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class RangeSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
 
   import RangeSupportSuite._
 

--- a/src/test/scala/sorm/test/types/SeqOfEntitiesSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/SeqOfEntitiesSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -9,7 +8,7 @@ import sorm._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class SeqOfEntitiesSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class SeqOfEntitiesSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import SeqOfEntitiesSupportSuite._
 
   def entities =  Set() + Entity[A]() + Entity[B]()

--- a/src/test/scala/sorm/test/types/SeqOfEnumsSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/SeqOfEnumsSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -11,7 +10,7 @@ import samples._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class SeqOfEnumsSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class SeqOfEnumsSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import SeqOfEnumsSupportSuite._
 
   def entities =  Set() + Entity[A]()

--- a/src/test/scala/sorm/test/types/SeqOfIntsSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/SeqOfIntsSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -11,7 +10,7 @@ import samples._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class SeqOfIntsSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class SeqOfIntsSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
   import SeqOfIntsSupportSuite._
 
   def entities =  Set() + Entity[A]()

--- a/src/test/scala/sorm/test/types/SeqOfSeqsSupportSuite.scala
+++ b/src/test/scala/sorm/test/types/SeqOfSeqsSupportSuite.scala
@@ -1,7 +1,6 @@
 package sorm.test.types
 
-import org.scalatest.FunSuite
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.{FunSuite, Matchers}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -11,7 +10,7 @@ import samples._
 import sorm.test.MultiInstanceSuite
 
 @RunWith(classOf[JUnitRunner])
-class SeqOfSeqsSupportSuite extends FunSuite with ShouldMatchers with MultiInstanceSuite {
+class SeqOfSeqsSupportSuite extends FunSuite with Matchers with MultiInstanceSuite {
 
   import SeqOfSeqsSupportSuite._
 


### PR DESCRIPTION
There are a few issues related to sext pom file.
Scalatest 3.0 has removed ShouldMatchers but org.scalatest.Matchers can be used instead.
https://github.com/sorm/sorm/issues/83